### PR TITLE
fix: Resolve deprecation warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,8 +47,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+        }
     }
     buildFeatures {
         compose = true

--- a/app/src/main/kotlin/io/github/b4tchkn/timez/core/NowLocalDateTime.kt
+++ b/app/src/main/kotlin/io/github/b4tchkn/timez/core/NowLocalDateTime.kt
@@ -12,6 +12,7 @@ interface NowLocalDateTime {
 
 object DefaultNowLocalDateTime : NowLocalDateTime {
     override val value: LocalDateTime
+        @OptIn(kotlin.time.ExperimentalTime::class)
         get() = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
 }
 

--- a/app/src/main/kotlin/io/github/b4tchkn/timez/core/NowLocalDateTime.kt
+++ b/app/src/main/kotlin/io/github/b4tchkn/timez/core/NowLocalDateTime.kt
@@ -1,7 +1,7 @@
 package io.github.b4tchkn.timez.core
 
 import androidx.compose.runtime.staticCompositionLocalOf
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime

--- a/app/src/main/kotlin/io/github/b4tchkn/timez/model/core/LocalDateTimeSerializer.kt
+++ b/app/src/main/kotlin/io/github/b4tchkn/timez/model/core/LocalDateTimeSerializer.kt
@@ -10,7 +10,9 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
 


### PR DESCRIPTION
This PR resolves deprecation warnings related to Kotlinx.datetime and jvmTarget.